### PR TITLE
feat: Implement speaker information modal

### DIFF
--- a/event_data.json
+++ b/event_data.json
@@ -18,7 +18,9 @@
         {
           "firstName": "Priya",
           "lastName": "Sharma",
-          "companyName": "InnovateAI Corp"
+          "companyName": "InnovateAI Corp",
+          "bio": "Priya Sharma is a leading expert in Artificial Intelligence, with over a decade of experience driving innovation at InnovateAI Corp. She specializes in machine learning and natural language processing.",
+          "imageUrl": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=PriyaS"
         }
       ],
       "categories": ["AI", "Machine Learning", "Future Tech"]
@@ -34,7 +36,9 @@
         {
           "firstName": "Raj",
           "lastName": "Patel",
-          "companyName": "CloudScale Solutions"
+          "companyName": "CloudScale Solutions",
+          "bio": "Raj Patel is a seasoned cloud architect with expertise in building scalable and resilient infrastructure. He is passionate about microservices and DevOps practices.",
+          "imageUrl": "https://via.placeholder.com/150/FF0000/FFFFFF?Text=RajP"
         }
       ],
       "categories": ["Web Development", "Microservices", "Architecture"]
@@ -50,7 +54,9 @@
         {
           "firstName": "Ananya",
           "lastName": "Singh",
-          "companyName": "SecureNet Systems"
+          "companyName": "SecureNet Systems",
+          "bio": "Ananya Singh is a cybersecurity expert with a focus on IoT security. She has extensive experience in ethical hacking and vulnerability assessment.",
+          "imageUrl": "https://via.placeholder.com/150/00FF00/FFFFFF?Text=AnanyaS"
         }
       ],
       "categories": ["Cybersecurity", "IoT", "Network Security"]
@@ -66,7 +72,9 @@
         {
           "firstName": "Vikram",
           "lastName": "Rao",
-          "companyName": "DataDriven Inc."
+          "companyName": "DataDriven Inc.",
+          "bio": "Vikram Rao is a data scientist and big data evangelist. He helps organizations leverage data analytics to drive business growth and innovation.",
+          "imageUrl": "https://via.placeholder.com/150/FFFF00/000000?Text=VikramR"
         }
       ],
       "categories": ["Big Data", "Data Analytics", "Business Intelligence"]
@@ -82,7 +90,9 @@
         {
           "firstName": "Meera",
           "lastName": "Desai",
-          "companyName": "QuantumLeap Tech"
+          "companyName": "QuantumLeap Tech",
+          "bio": "Meera Desai is a quantum physicist and researcher at the forefront of quantum computing. She is dedicated to advancing the field and exploring its potential applications.",
+          "imageUrl": "https://via.placeholder.com/150/00FFFF/000000?Text=MeeraD"
         }
       ],
       "categories": ["Quantum Computing", "Future Tech", "Physics"]

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,48 @@
         .search-controls input[type="text"] { flex-grow: 1; padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
         .search-controls button { padding: 10px 15px; background-color: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer; }
         .search-controls button { padding: 10px 15px; background-color: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer; }
+
+        /* Modal styles */
+        .modal {
+            display: none; /* Hidden by default */
+            position: fixed; /* Stay in place */
+            z-index: 1000; /* Sit on top */
+            left: 0;
+            top: 0;
+            width: 100%; /* Full width */
+            height: 100%; /* Full height */
+            overflow: auto; /* Enable scroll if needed */
+            background-color: rgba(0,0,0,0.5); /* Black w/ opacity */
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal-content {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+            width: 80%;
+            max-width: 500px;
+            position: relative; /* For positioning the close button */
+            text-align: center; /* Center content like image and text */
+        }
+
+        .close-button {
+            position: absolute;
+            top: 10px;
+            right: 15px;
+            font-size: 24px;
+            font-weight: bold;
+            color: #aaa; /* Lighter color for the close button */
+            cursor: pointer;
+        }
+        .close-button:hover,
+        .close-button:focus {
+            color: black; /* Darker on hover/focus for better feedback */
+            text-decoration: none;
+        }
     </style>
 </head>
 <body>
@@ -53,7 +95,16 @@
                         <p class="talk-meta">
                             <strong>Speakers:</strong>
                             {% for speaker in talk.speakers %}
-                                {{ speaker.firstName }} {{ speaker.lastName }} ({{ speaker.companyName }}){% if not loop.last %}, {% endif %}
+                                <span class="speaker-name"
+                                      data-firstname="{{ speaker.firstName }}"
+                                      data-lastname="{{ speaker.lastName }}"
+                                      data-company="{{ speaker.companyName }}"
+                                      data-bio="{{ speaker.bio | e }}"
+                                      data-imageurl="{{ speaker.imageUrl }}"
+                                      data-talkid="{{ talk.id }}"
+                                      style="cursor: pointer; text-decoration: underline; color: #0056b3;">
+                                    {{ speaker.firstName }} {{ speaker.lastName }}
+                                </span> ({{ speaker.companyName }}){% if not loop.last %}, {% endif %}
                             {% endfor %}
                         </p>
                         <p class="talk-categories talk-meta">
@@ -132,7 +183,53 @@
             // or if we want to handle the "no talks found" message initially if needed.
             // For now, it just ensures consistency.
             filterTalks();
+
+            // Speaker Modal Logic
+            const speakerModal = document.getElementById('speakerModal');
+            const speakerModalImage = document.getElementById('speakerModalImage');
+            const speakerModalName = document.getElementById('speakerModalName');
+            const speakerModalCompany = document.getElementById('speakerModalCompany');
+            const speakerModalBio = document.getElementById('speakerModalBio');
+            const closeButton = speakerModal.querySelector('.close-button');
+            const speakerNameElements = document.querySelectorAll('.speaker-name');
+
+            speakerNameElements.forEach(speakerElement => {
+                speakerElement.addEventListener('click', function() {
+                    // Populate modal
+                    speakerModalName.textContent = `${this.dataset.firstname} ${this.dataset.lastname}`;
+                    speakerModalCompany.textContent = this.dataset.company;
+                    speakerModalBio.textContent = this.dataset.bio;
+                    speakerModalImage.src = this.dataset.imageurl;
+                    speakerModalImage.alt = `Image of ${this.dataset.firstname} ${this.dataset.lastname}`;
+
+                    // Display modal
+                    speakerModal.style.display = 'flex'; // Using flex as per CSS
+                });
+            });
+
+            // Event Listener for Close Button
+            closeButton.addEventListener('click', function() {
+                speakerModal.style.display = 'none';
+            });
+
+            // Event Listener for Clicking Outside Modal
+            window.addEventListener('click', function(event) {
+                if (event.target === speakerModal) {
+                    speakerModal.style.display = 'none';
+                }
+            });
         });
     </script>
+
+    <!-- Speaker Modal HTML -->
+    <div id="speakerModal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <img id="speakerModalImage" src="" alt="Speaker Image" style="max-width: 150px; border-radius: 50%; margin-bottom: 15px;">
+            <h3 id="speakerModalName" style="margin-bottom: 5px;"></h3>
+            <p id="speakerModalCompany" style="margin-top: 0; margin-bottom: 10px; color: #555;"></p>
+            <p id="speakerModalBio" style="font-size: 0.9em; line-height: 1.5;"></p>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a modal dialog that displays detailed information about a speaker when their name is clicked in the talk details.

Key changes:
- Updated `event_data.json` to include `bio` and `imageUrl` fields for each speaker.
- Modified `templates/index.html`:
    - Added HTML structure for the modal.
    - Included CSS for basic modal styling and layout.
    - Updated speaker names to be clickable triggers for the modal, embedding speaker data using `data-*` attributes.
    - Implemented JavaScript to handle modal opening, population with speaker data (name, image, bio, company), and closing (via button or clicking outside).

The modal enhances your experience by providing easy access to speaker biographies and images without navigating away from the event schedule.